### PR TITLE
add_cocoon_to_products_new(sakusabe)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,12 +66,11 @@ gem 'refile-mini_magick'
 gem 'ransack'
 gem 'rails_admin'
 gem 'enum_help'
-
 gem 'rails-i18n'
-
 gem 'kaminari'
 gem "pry-rails"
-
 gem 'cancan'
+gem 'cocoon'
+gem 'jquery-rails'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -62,24 +60,14 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
-
-    capybara (3.11.1)
-
     cancan (1.6.10)
-    capybara (3.10.1)
-
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
+    capybara (3.11.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    cocoon (1.2.12)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -114,9 +102,6 @@ GEM
       domain_name (~> 0.5)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    i18n_generators (2.2.0)
-      activerecord (>= 3.0.0)
-      railties (>= 3.0.0)
     io-like (0.3.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -173,7 +158,6 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.7)
       pry (>= 0.10.4)
-    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
     rack-pjax (1.0.0)
@@ -235,7 +219,6 @@ GEM
     refile-mini_magick (0.2.0)
       mini_magick (~> 4.0)
       refile (~> 0.5)
-    regexp_parser (1.3.0)
     remotipart (1.4.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -302,8 +285,6 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -314,11 +295,12 @@ DEPENDENCIES
   cancan
   capybara (>= 2.15)
   chromedriver-helper
+  cocoon
   coffee-rails (~> 4.2)
   devise
   enum_help
-  i18n_generators
   jbuilder (~> 2.5)
+  jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
   pry-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,8 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+
+
+// jqueryとcocoonをインストールしたため必要な記述
+//= require jquery
+//= require cocoon

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -32,14 +32,13 @@ header {
 	width: 100%;
 	height: 70px;
 	margin: 0 auto;
-
+}
 
 footer {
 	background-color: rgb(200, 250, 220);
 	width: 100%;
 	height: 60px;
 	margin: 0 auto;
-
 }
 
 

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -15,7 +15,6 @@
 
 .product_new_big_box{
 	width: 60%;
-	height: 800px;
 	margin: 0 auto;
 	overflow: hidden;
 }
@@ -25,18 +24,25 @@
 
 .product_new_middle_box{
 	width: 60%;
-	height: 800px;
 	margin: 0 auto;
 	margin-top: 20px;
 	padding-left: 30px;
 	overflow: hidden;
-
 }
 
 .product_new_btn{
 	width:400px;
 	height:200px;
 }
+
+/*cocoonで作成できるディスクの箱*/
+.products_new_disc_form {
+	background-color: white;
+	width: 95%;
+	margin: 2% 0%;
+	border: 1px solid #999999;
+}
+
 /*---------------------------------------------------------------詳細ページ*/
 .product_show_big_box{
 	width:80%;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -28,7 +28,7 @@ class ProductsController < ApplicationController
       redirect_to products_path
     else
       @product.errors.full_messages
-      render "mails/new"
+      render "products/new"
     end
 
   end
@@ -45,7 +45,10 @@ class ProductsController < ApplicationController
   private
   def product_params
 
-    params.require(:product).permit(:artist,:album,:title,:image,:label,:genre,:status,:introduction,:count,:price)
+    params.require(:product).permit(:artist,:album,:title,:image,:label,:genre,:status,:introduction,:count,:price,
+                                    discs_attributes: [:id, :number, :_destroy,
+                                    songs_attributes: [:id, :title, :_destroy]])
   end
+
 
 end

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -1,4 +1,5 @@
 class Disc < ApplicationRecord
 	belongs_to :product
-	has_many :songs
+	has_many :songs, inverse_of: :disc
+	accepts_nested_attributes_for :songs, allow_destroy: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,20 +1,21 @@
 class Product < ApplicationRecord
-	 enum genre: {J_POP: 0, 洋楽: 1, K_POP: 2, アニメ: 3, HIP_POP: 4, レゲエ: 5,
-	 	ロック: 6, 演歌: 7, エレクトロニック: 8, クラシック: 9, メタル: 10}
-	 enum status: {新品: 0, 未使用に近い: 1, 目立った傷汚れなし: 2, 傷汚れあり: 3, 状態が悪い: 4}
-	 validates :artist, {presence:true}
-	 validates :album, {presence:true}
-	 validates :label, {presence:true}
-	 validates :genre, {presence:true}
-	 validates :status, {presence:true}
-	 validates :introduction, {presence:true}
-	 validates :count, {presence:true}
-	 validates :price, {presence:true}
-
+	enum genre: {J_POP: 0, 洋楽: 1, K_POP: 2, アニメ: 3, HIP_POP: 4, レゲエ: 5,ロック: 6, 演歌: 7, エレクトロニック: 8, クラシック: 9, メタル: 10}
+	enum status: {新品: 0, 未使用に近い: 1, 目立った傷汚れなし: 2, 傷汚れあり: 3, 状態が悪い: 4}
+	validates :artist, {presence:true}
+	validates :album, {presence:true}
+	validates :label, {presence:true}
+	validates :genre, {presence:true}
+	validates :status, {presence:true}
+	validates :introduction, {presence:true}
+	validates :count, {presence:true}
+	validates :price, {presence:true}
 
 	belongs_to :user
 	has_many :product_comments
-	has_many :discs
+
+ 	has_many :discs, inverse_of: :product
+	accepts_nested_attributes_for :discs, allow_destroy: true
+
 	has_many :prices
 	has_many :cart_products
 	has_many :buy_products

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,7 +36,7 @@
 
   <div class="field">
     <%= f.label :郵便番号 %><br />
-    <%= f.text_field :portal %>
+    <%= f.text_field :postal %>
   </div>
 
   <div class="field">

--- a/app/views/products/_disc_fields.html.erb
+++ b/app/views/products/_disc_fields.html.erb
@@ -1,0 +1,12 @@
+<div class="products_new_disc_form">
+
+	<h4>ディスクの曲名</h4>
+	<div class="nested-fields">
+			<%= f.fields_for :songs do |f| %>
+				<%= render 'song_fields', f: song %>
+			<% end %>
+
+			<%= link_to_add_association '曲名を追加する', f, :songs %>
+
+	</div>
+</div>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,0 +1,6 @@
+<!-- new.html.erbで呼び出される内容 -->
+<!-- 下記のf.fields_forは form_forで f. を作らないと利用不可っぽいです -->
+<%= form_for @product do |f| %>
+
+
+<% end %>

--- a/app/views/products/_song_fields.html.erb
+++ b/app/views/products/_song_fields.html.erb
@@ -1,0 +1,3 @@
+<div>
+	・<%= f.text_field :title %>
+</div>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -19,6 +19,22 @@
 
 	<h2>状態</h2>
 	<%= f.select :status,Product.statuses.keys.to_a, {} %>
+
+	<h2>ディスク</h2>
+
+	<div>
+		<!-- f.fields_forは、cocoonをインストールすると使用できる？っぽいです -->
+		<!-- ほぼform_forと機能は同じです。 -->
+		<!-- 異なるのは、①上述の通りネストしたモデルの内容をparams回収ができる点、②下記のlink_to_add_associationのリンクが押されると表示できる点 -->
+		<%= f.fields_for :discs do |disc| %>
+			<!-- renderで部分テンプレートdiscs_fields.html.erbを呼び出している。上記②の通り下記のlink_to_add_associationを押すことで呼び出す。 -->
+			<%= render 'disc_fields', f: disc %>
+		<% end %>
+
+		<!-- 通常のlink_to のjquery版。これを押すと上記のrenderが呼び出される。 -->
+		<%= link_to_add_association 'ディスクを追加', f, :discs  %>
+	</div>
+
 	<h1> CDの説明</h1>
 	<%= f.text_area :introduction, cols:70, rows:10 %>
 	<h1>数量</h1>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_18_064917) do
-
+ActiveRecord::Schema.define(version: 2018_11_20_040329) do
 
   create_table "buy_products", force: :cascade do |t|
     t.integer "count"
@@ -61,6 +59,7 @@ ActiveRecord::Schema.define(version: 2018_11_18_064917) do
     t.integer "product_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "number"
   end
 
   create_table "mails", force: :cascade do |t|
@@ -141,8 +140,8 @@ ActiveRecord::Schema.define(version: 2018_11_18_064917) do
     t.datetime "updated_at", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "postal"
     t.boolean "admin"
+    t.string "postal"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
branch名はテストですが、テスト成功したのでそのままpushします。
【概要】
cocoonを実装したことにより、ディスク項目の作成、その中に曲名の小項目を作成することができます。

【主な変更点】
下記の2点です。
①Productモデルにaccepts_nested_attributes_for ：discsの記載
Discモデルにaccepts_nested_attributes_for：songsの記載。
→ストロングパラメータでProductモデルを指定して、discsとsongsを回収することができる。

②renderと部分テンプレート
→cocoonをインストールすることにより、使用できるヘルパーメソッド？的なlink_to_add_asspciation_　で用意されたリンクを押すと、render以下の部分テンプレートをよびだせる。

以上です。