### PR TITLE
add_logic_deete_to_user_show(sakusabe)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,8 +26,11 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    
+    @user = User.find(params[:id])
+    @user.update_attribute(:deleted_at, 1)
+    redirect_to new_user_registration_path
   end
+
 
   private
   def user_params

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,7 +4,7 @@ class Product < ApplicationRecord
 	 	rock: 6, ballad: 7, electronuc: 8, classic: 9, metal: 10}
 	 # enum genre: {aaa: 0, abb: 1, ccc: 3}
 	 enum status: {新品: 0, 未使用に近い: 1, 目立った傷汚れなし: 2, 傷汚れあり: 3, 状態が悪い: 4}
-	 
+
 	 validates :artist, {presence:true}
 	 validates :album, {presence:true}
 	 validates :label, {presence:true}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,15 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  enum deleted_at: {登録中: 0, 退会済み: 1}
+
+  def active_for_authentication?
+    super && self.deleted_at == "登録中"
+  end
+
+  def inactive_message
+    self.deleted_at == "登録中" ? super: :退会済みのユーザーです
+  end
 
    has_many :mails
    has_many :products
@@ -22,6 +31,5 @@ class User < ApplicationRecord
    validates :tel, length:{maximum:11}
    validates :postal, length:{is:7}
    validates :password,length:{minimum:6}
-
 
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,6 @@
+<% @user.errors.full_messages do |m| %>
+<%= m %>
+<% end %>
 <div class="users_show_mypage">
 	<div class="users_show_left">
 		<h2>マイアカウント</h2>
@@ -12,15 +15,15 @@
 				<p><%= @user.profile %></p>
 			</div>
 			<% if @user == current_user %>
-			<div>
-				<h2><%= link_to "購入履歴", buy_path(@user.id)%></h2>
-			</div>
-			<div>
-				<h2><%= link_to "編集", edit_user_path(@user.id) %></h2>
-			</div>
-			<div>
-				<h3><%= link_to "退会" %></h3>
-			</div>
+				<div>
+					<h2><%= link_to "購入履歴", buy_path(@user.id)%></h2>
+				</div>
+				<div>
+					<h2><%= link_to "編集", edit_user_path(@user.id) %></h2>
+				</div>
+				<div>
+					<h3><%= link_to "退会", user_path(@user.id), method: :delete, "data-confirm" => "本当に退会しますか？" %></h3>
+				</div>
 			<% end %>
 
 		</div>

--- a/db/migrate/20181126070308_change_deta_deleted_at_from_users.rb
+++ b/db/migrate/20181126070308_change_deta_deleted_at_from_users.rb
@@ -1,0 +1,5 @@
+class ChangeDetaDeletedAtFromUsers < ActiveRecord::Migration[5.2]
+  def change
+  	change_column :users, :deleted_at, :boolean
+  end
+end

--- a/db/migrate/20181126074902_change_data_integer_from_boolean_from_users.rb
+++ b/db/migrate/20181126074902_change_data_integer_from_boolean_from_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataIntegerFromBooleanFromUsers < ActiveRecord::Migration[5.2]
+  def change
+  	  change_column :users, :deleted_at, :integer
+  end
+end

--- a/db/migrate/20181126075626_add_default_deleted_at_from_users.rb
+++ b/db/migrate/20181126075626_add_default_deleted_at_from_users.rb
@@ -1,0 +1,5 @@
+class AddDefaultDeletedAtFromUsers < ActiveRecord::Migration[5.2]
+  def change
+  	change_column :users, :deleted_at, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2018_11_20_040329) do
-
+ActiveRecord::Schema.define(version: 2018_11_26_075626) do
 
   create_table "buy_products", force: :cascade do |t|
     t.integer "count"
@@ -137,7 +135,7 @@ ActiveRecord::Schema.define(version: 2018_11_20_040329) do
     t.string "tel"
     t.text "image_id"
     t.text "profile"
-    t.datetime "deleted_at"
+    t.integer "deleted_at", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email", default: "", null: false


### PR DESCRIPTION
user_show画面（マイページ画面）に退会ボタンを押したときにそのユーザーのデータを論理削除する機能を追加しました。

主な変更点
・Userモデルに deleted_atカラム（integer）の追加。デフォルトは0になるようにしている。
・deleted_atカラムにenum　登録中は0 退会済みは1　の追加
・usersコントローラーのdestroyアクションで、退会ボタンを押した場合に  deleted_atカラムに1が入るようにした（passwordが入らないためvalidateにより弾かれるが、validateを無視するupdate_attributeで保存）。
・Userモデルに authenticateをオーバーライドしてdeleted_atが1のときはログインできないように修正。